### PR TITLE
Rules order

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,6 +16,9 @@ export default {
       let { style, pseudos, mediaQueries } = seperateStyles( styles[key] );
       const className = createClassName( sortObject( style ));
 
+      if ( !stylesheet.has( className ) )
+        stylesheet.set( className, style );
+
       if ( pseudos.length ) {
         pseudos.map( selector => {
           const pseudoClassName = `${className}${selector}`;
@@ -42,9 +45,6 @@ export default {
             .set( className, styles[key][selector] );
         });
       }
-
-      if ( !stylesheet.has( className ) )
-        stylesheet.set( className, style );
 
       acc[ key ] = className;
       return acc;


### PR DESCRIPTION
Hey @chriskjaer,

I changed the order of the rules in the css because the media queries should be at the end of the file.

Before (the `width` in the class wins):
```
@media (max-width: 480px) {
    ._1protfs {
        width: 160px;
    }
}
._1protfs {
    width: 320px;
}
```

After (the `width` in the media query wins):
```
._57kv2x {
    width: 320px;
}
@media (max-width: 480px) {
    ._57kv2x {
        width: 160px;
    }
}
```

Tests are green :)
